### PR TITLE
Change base image to rocker/binder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/verse:latest
+FROM rocker/binder:4
 
 ENV PLINK_VERSION=latest
 ENV PLINK_ZIP=plink_linux_x86_64_${PLINK_VERSION}.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM rocker/binder:4
 
+USER root
+
 ENV PLINK_VERSION=latest
 ENV PLINK_ZIP=plink_linux_x86_64_${PLINK_VERSION}.zip
 ENV PLINK_HOME=/usr/local/plink

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Genetics analysis stack downstream of rocker
 
 Adds common genetics software (PLINK, vcftools, bcftools) and R packages
-(chiefly GENESIS) to the rocker/binder image.
+(chiefly GENESIS) to the rocker/binder image. See rocker documentation for
+accessing RStudio Server and Jupyter through a web browser.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Genetics analysis stack downstream of rocker
+
+Adds common genetics software (PLINK, vcftools, bcftools) and R packages
+(chiefly GENESIS) to the rocker/binder image.


### PR DESCRIPTION
Reverts R version back to 4.4.2. Run as root when building image. Base image (binder) is downstream of the base image previously used (verse).