### PR TITLE
Add Snakemake and change base image to rocker/verse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
     `# navigate to temp directory for setup` \
      mkdir setuptemp && cd setuptemp && \
     `# update packages` \
-    apt-get update && apt-get upgrade && \
+    apt-get update && apt-get upgrade -y && \
     `# install gnu parallel snakemake and jq ` \
     apt-get install -y parallel snakemake jq && \
     `# install PLINK` \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
     `# navigate to temp directory for setup` \
      mkdir setuptemp && cd setuptemp && \
     `# update packages` \
-    apt-get update && apt-get-upgrade && \
+    apt-get update && apt-get upgrade && \
     `# install gnu parallel snakemake and jq ` \
     apt-get install -y parallel snakemake jq && \
     `# install PLINK` \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/binder:4
+FROM rocker/verse:4.5.1
 
 USER root
 
@@ -13,7 +13,7 @@ RUN \
     `# navigate to temp directory for setup` \
      mkdir setuptemp && cd setuptemp && \
     `# update packages` \
-    apt-get update && \
+    apt-get update && apt-get-upgrade && \
     `# install gnu parallel snakemake and jq ` \
     apt-get install -y parallel snakemake jq && \
     `# install PLINK` \


### PR DESCRIPTION
Change base image back to verse so we have an analysis image that's more current and works better for interactive use not through a server running RStudio or jupyter. Install Snakemake with apt. Add missing `apt-get upgrade` call.